### PR TITLE
Initial ratelimiting config

### DIFF
--- a/manifests/rhcl/kuadrant.yaml
+++ b/manifests/rhcl/kuadrant.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-100"
+---
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+  namespace: kuadrant-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-20"
+spec: {}
+# todo: wasm-plugin-pull-secret

--- a/manifests/sampleapps/bookinfo/rate-limiting/bookinfo-policy.yaml
+++ b/manifests/sampleapps/bookinfo/rate-limiting/bookinfo-policy.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuadrant.io/v1
+kind: RateLimitPolicy
+metadata:
+  name: bookinfo-rlp
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: bookinfo
+  defaults:
+    when:
+      - predicate: "'my-rl-header' in request.headers"
+    limits:
+      "low-limit":
+        rates:
+          - limit: 5
+            window: 10s


### PR DESCRIPTION
- Create Kuadrant resource
- Rate limiting for the bookinfo route, 5 requests every 10s when 'my-rl-header' present